### PR TITLE
Fix Alignment on Contents Page

### DIFF
--- a/backend/server/reportData/css/_toc-page.css/content.css
+++ b/backend/server/reportData/css/_toc-page.css/content.css
@@ -30,9 +30,11 @@
     color: var(--shark);
 }
 
-#toc-page-es a[href="#organisational-maturity-page-es"] .toc-page__sections {
+#toc-page-es a[href="#organisational-maturity-page-es"] .toc-page__sections,
+#toc-page-en a[href="#organisational-maturity-page"] .toc-page__sections {
     margin-left: 17.3mm;
 }
-#toc-page-es a[href="#continuous-delivery-page-es"] .toc-page__sections {
+#toc-page-es a[href="#continuous-delivery-page-es"] .toc-page__sections,
+#toc-page-en a[href="#continuous-delivery-page"] .toc-page__sections {
     margin-left: 19mm;
 }


### PR DESCRIPTION
This PR aligns the first two entries within the EN contents page to keep everything aligned.