### PR TITLE
Update HubSpot Tracking

### DIFF
--- a/backend/server/src/report/hubspot/api.js
+++ b/backend/server/src/report/hubspot/api.js
@@ -120,6 +120,7 @@ const submitForm = (pdfLink, user, scores) => {
           },
         },
         context: {
+          hutk: user.hutk,
           ipAddress: user.ip,
         },
       },

--- a/client/src/Acceptance.test.jsx
+++ b/client/src/Acceptance.test.jsx
@@ -11,6 +11,7 @@ import translator from './config/translator';
 import payloadRequest from './mockdata/post_survey_request_body.json';
 import testHelpers from './mockdata/testHelpers';
 import reportService from './services/reportService';
+import cookieService from './services/cookieService';
 import ipProvider from './services/ipProvider';
 
 reactTransitionGroupConfig.disabled = true;
@@ -51,6 +52,9 @@ const submitSurveySpy = jest.spyOn(reportService, 'submitSurvey');
 const ipProviderSpy = jest
   .spyOn(ipProvider, 'getIp')
   .mockImplementation(() => Promise.resolve('mockedIp'));
+const getCookieSpy = jest
+  .spyOn(cookieService, 'getCookie')
+  .mockImplementation(() => 'hubspotutkCookie');
 const returnFromAsync = (spy) => spy.mock.results[0].value;
 
 /*
@@ -111,5 +115,6 @@ describe('acceptance test', () => {
     const result = await returnFromAsync(submitSurveySpy);
     expect(result).toEqual(successfulResponseFromBackend);
     expect(ipProviderSpy).toHaveBeenCalledTimes(1);
+    expect(getCookieSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/client/src/components/ReportArea/OrganisationalCultureReportArea.jsx
+++ b/client/src/components/ReportArea/OrganisationalCultureReportArea.jsx
@@ -5,7 +5,7 @@ import './styles.scss';
 export default function OrganisationalCultureReportArea() {
   return (
     <svg
-      class="report-area-icon"
+      className="report-area-icon"
       id="culture"
       viewBox="0 0 100 100"
       role="presentation"

--- a/client/src/components/UserForm/UserForm.jsx
+++ b/client/src/components/UserForm/UserForm.jsx
@@ -8,6 +8,7 @@ import userFormValues from '../../config/userFormValues';
 import privacyPolicyUrl from '../../services/privacyPolicyUrl';
 import './styles.scss';
 
+// eslint-disable-next-line no-control-regex
 const emailRegex = /(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9]))\.){3}(?:(2(5[0-5]|[0-4][0-9])|1[0-9][0-9]|[1-9]?[0-9])|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])/;
 const {
   userFormTitle,

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -226,6 +226,8 @@
       }
     </style>
 
+    <div id="root"></div>
+
     <!-- Start of HubSpot Embed Code -->
     <script
       type="text/javascript"
@@ -234,11 +236,8 @@
       defer
       src="//js.hs-scripts.com/3042464.js"
     ></script>
-
     <!-- End of HubSpot Embed Code -->
-
     <!-- End of HubSpot code snippet -->
-    <div id="root"></div>
     <style>
       div#hs-eu-cookie-confirmation
         div#hs-eu-cookie-confirmation-inner

--- a/client/src/mockdata/post_survey_request_body.json
+++ b/client/src/mockdata/post_survey_request_body.json
@@ -6,7 +6,8 @@
     "company": "Some Company",
     "email": "user@company.com",
     "jobFunction": "Founder/ CEO",
-    "language": "en"
+    "language": "en",
+    "hutk": "hubspotutkCookie"
   },
   "categories": {
     "organisationalMaturity": {

--- a/client/src/services/cookieService.js
+++ b/client/src/services/cookieService.js
@@ -1,0 +1,19 @@
+export default {
+  getCookie(cookieKey) {
+    const cookiesArray = document.cookie.split('; ');
+    const chosenCookie = cookiesArray.find((cookie) =>
+      cookie.includes(cookieKey)
+    );
+
+    if (chosenCookie === undefined) {
+      // eslint-disable-next-line no-console
+      console.error(`Unable to find chosen cookie ${cookieKey}`);
+    }
+
+    const chosenCookieValue = chosenCookie.substr(
+      chosenCookie.indexOf('=') + 1,
+      chosenCookie.length
+    );
+    return chosenCookieValue;
+  },
+};

--- a/client/src/services/reportService.js
+++ b/client/src/services/reportService.js
@@ -2,6 +2,7 @@ import fetch from 'node-fetch';
 import config from '../config/config';
 import ipProvider from './ipProvider';
 import languageService from './languageService';
+import cookieService from './cookieService';
 
 export default {
   async submitSurvey(surveyData) {
@@ -14,6 +15,7 @@ export default {
         email: surveyData.email,
         jobFunction: surveyData.jobFunction,
         language: languageService.getLanguage(),
+        hutk: cookieService.getCookie('hubspotutk'),
       },
       categories: surveyData.categories,
     };
@@ -22,6 +24,7 @@ export default {
       body: JSON.stringify(bodyPayload),
       headers: { 'Content-Type': 'application/json' },
     }).then((success) => {
+      // eslint-disable-next-line no-console
       console.log('response successful ', success);
       return { status: 'ok' };
     });

--- a/client/src/services/reportService.test.js
+++ b/client/src/services/reportService.test.js
@@ -4,6 +4,7 @@ import config from '../config/config';
 import payloadRequest from '../mockdata/post_survey_request_body.json';
 import surveyData from '../mockdata/survey_mock_data.json';
 import reportService from './reportService';
+import cookieService from './cookieService';
 import ipProvider from './ipProvider';
 
 const successfulResponseFromBackend = { status: 'ok' };
@@ -16,11 +17,16 @@ const ipProviderSpy = jest
   .spyOn(ipProvider, 'getIp')
   .mockImplementation(() => Promise.resolve('mockedIp'));
 
+const getCookieSpy = jest
+  .spyOn(cookieService, 'getCookie')
+  .mockImplementation(() => 'hubspotutkCookie');
+
 describe('report service', () => {
   it('should returns successful response when we submit a survey', async () => {
     const response = await reportService.submitSurvey(surveyData);
 
     expect(response).toEqual(successfulResponseFromBackend);
     expect(ipProviderSpy).toHaveBeenCalledTimes(1);
+    expect(getCookieSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
This PR aims to solve the issue of the lead source not being attributed to the contacts being made in Hubspot. 

Submitting the form will now submit the hubspututk cookie value for the contact, which should correctly attribute the source of the contact.